### PR TITLE
Fix script to cope with apk file names containing spaces

### DIFF
--- a/addSecurityExceptions.sh
+++ b/addSecurityExceptions.sh
@@ -30,21 +30,21 @@ new="_new.apk"
 newFileName=$filename$new
 tmpDir=/tmp/$filename
 
-java -jar "$DIR/apktool.jar" d -f -o $tmpDir $fullfile
+java -jar "$DIR/apktool.jar" d -f -o "$tmpDir" "$fullfile"
 
 if [ ! -d "$tmpDir/res/xml" ]; then
-	mkdir $tmpDir/res/xml
+	mkdir "$tmpDir/res/xml"
 fi
 
-cp "$DIR/network_security_config.xml" $tmpDir/res/xml/.
-if ! grep -q "networkSecurityConfig" $tmpDir/AndroidManifest.xml; then
-  sed -E "s/(<application.*)(>)/\1 android\:networkSecurityConfig=\"@xml\/network_security_config\" \2 /" $tmpDir/AndroidManifest.xml > $tmpDir/AndroidManifest.xml.new
-  mv $tmpDir/AndroidManifest.xml.new $tmpDir/AndroidManifest.xml
+cp "$DIR/network_security_config.xml" "$tmpDir/res/xml/."
+if ! grep -q "networkSecurityConfig" "$tmpDir/AndroidManifest.xml"; then
+  sed -E "s/(<application.*)(>)/\1 android\:networkSecurityConfig=\"@xml\/network_security_config\" \2 /" "$tmpDir/AndroidManifest.xml" > "$tmpDir/AndroidManifest.xml.new"
+  mv "$tmpDir/AndroidManifest.xml.new" "$tmpDir/AndroidManifest.xml"
 fi
 
 
-java -jar "$DIR/apktool.jar" empty-framework-dir --force $tmpDir
+java -jar "$DIR/apktool.jar" empty-framework-dir --force "$tmpDir"
 echo "Building new APK $newFileName"
-java -jar "$DIR/apktool.jar" b -o ./$newFileName $tmpDir
-jarsigner -verbose -keystore $debugKeystore -storepass android -keypass android ./$newFileName androiddebugkey
+java -jar "$DIR/apktool.jar" b -o "./$newFileName" "$tmpDir"
+jarsigner -verbose -keystore $debugKeystore -storepass android -keypass android "./$newFileName" androiddebugkey
 


### PR DESCRIPTION
addSecurityExceptions.sh couldn't handle apk file names that contained spaces.