### PR TITLE
Add zipalign step

### DIFF
--- a/addSecurityExceptions.sh
+++ b/addSecurityExceptions.sh
@@ -27,6 +27,8 @@ filename=$(basename "$fullfile")
 extension="${filename##*.}"
 filename="${filename%.*}"
 new="_new.apk"
+temp="_temp.apk"
+tempFileName=$filename$temp
 newFileName=$filename$new
 tmpDir=/tmp/$filename
 
@@ -44,7 +46,9 @@ fi
 
 
 java -jar "$DIR/apktool.jar" empty-framework-dir --force "$tmpDir"
-echo "Building new APK $newFileName"
-java -jar "$DIR/apktool.jar" b -o "./$newFileName" "$tmpDir"
-jarsigner -verbose -keystore $debugKeystore -storepass android -keypass android "./$newFileName" androiddebugkey
-
+echo "Building temp APK $tempFileName"
+java -jar "$DIR/apktool.jar" b -o "./$tempFileName" "$tmpDir"
+jarsigner -verbose -keystore $debugKeystore -storepass android -keypass android "./$tempFileName" androiddebugkey
+zipalign -p 4 $tempFileName $newFileName
+rm -rf $tempFileName
+echo "Resigned APK successfully $newFileName"


### PR DESCRIPTION
As mentioned here https://github.com/levyitay/AddSecurityExceptionAndroid/issues/31#issuecomment-716144487 the APK needs to be zipaligned otherwise this error will be thrown when installing:
`Failure [INSTALL_FAILED_INVALID_APK: Failed to extract native libraries, res=-2]`